### PR TITLE
Fix cli argv increment

### DIFF
--- a/examples/bert.rs
+++ b/examples/bert.rs
@@ -60,8 +60,8 @@ pub fn main() -> Result<(), BertError> {
                 return Ok(());
             } else {
                 string.push_str(&args[i]);
-                i += 1;
             }
+            i += 1;
         }
         (n, string)
     } else {

--- a/examples/bert_gpu.rs
+++ b/examples/bert_gpu.rs
@@ -275,8 +275,8 @@ pub fn run() -> Result<(), BertError> {
                 return Ok(());
             } else {
                 string.push_str(&args[i]);
-                i += 1;
             }
+            i += 1;
         }
         (n, string)
     } else {


### PR DESCRIPTION
When you run an example
```bash
cargo run --example bert --release --features intel-mkl -- "This is a test" -n 3
```
it was:
```
Running bert inference on `"This is a test3"`
# notice -n 3 is added to text "This is a test3"
```

and this PR fixed it

cc: @Narsil (github is not letting me add you as a reviewr)