### PR TITLE
Fix cuda copy function

### DIFF
--- a/src/gpu/f32/ops.rs
+++ b/src/gpu/f32/ops.rs
@@ -79,7 +79,7 @@ pub fn select(ids: &[usize], weights: &Tensor, out: &mut Tensor) -> Result<(), S
 
 /// Copy tensor into another tensor
 pub fn copy(weights: &Tensor, out: &mut Tensor) -> Result<(), SmeltError> {
-    out.device().dtod_copy(weights.data(), out.data_mut())?;
+    weights.device().dtod_copy(weights.data(), out.data_mut())?;
     Ok(())
 }
 

--- a/src/gpu/f32/tensor.rs
+++ b/src/gpu/f32/tensor.rs
@@ -32,6 +32,14 @@ impl Device {
     }
 }
 
+impl std::ops::Deref for Device {
+    type Target = Arc<CudaDevice>;
+    /// TODO
+    fn deref(&self) -> &Self::Target {
+        &self.device
+    }
+}
+
 impl Tensor {
     /// The shape of the tensor
     /// ```


### PR DESCRIPTION
There was error in [copy](https://github.com/Narsil/smelte-rs/blob/587c57eb36cc4712e519ac711543da94f1c52819/src/gpu/f32/ops.rs#L81) function that was not letting smelte-rs compile when cuda flag is enabled.

To fix it, 2 changes were needed:
1. Copy function refers to [Device's cudaDevice](https://github.com/Narsil/smelte-rs/blob/587c57eb36cc4712e519ac711543da94f1c52819/src/gpu/f32/tensor.rs#L17) attribute for dtot_copy method. Therefore, I added Deref https://github.com/Narsil/smelte-rs/blob/587c57eb36cc4712e519ac711543da94f1c52819/src/gpu/f32/tensor.rs#L35-L41
2. With change number 1 done, there was issue about immut borrow & mut borrow of `out` being at the same time. Theefore, changed it to `weights`